### PR TITLE
Replace image absolute paths with relative paths in css

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -164,6 +164,7 @@ module.exports = {
                 loader: require.resolve('css-loader'),
                 options: {
                   importLoaders: 1,
+                  url: false,
                 },
               },
               {

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -181,6 +181,7 @@ module.exports = {
                       loader: require.resolve('css-loader'),
                       options: {
                         importLoaders: 1,
+                        url: false,
                         minimize: true,
                         sourceMap: shouldUseSourceMap,
                       },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "react-markdown": "^3.3.0",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
-    "sass": "^1.1.1",
     "style-loader": "0.19.0",
     "sw-precache-webpack-plugin": "0.11.4",
     "tachyons-sass": "^4.9.2",
@@ -55,13 +54,18 @@
     "whatwg-fetch": "2.0.3"
   },
   "scripts": {
-    "start": "sass --watch src/styles/scss:src/styles/css | node scripts/start.js",
-    "build": "sass src/styles/scss/main.scss src/styles/css/main.css | node scripts/build.js",
+    "build-css": "node-sass-chokidar src/styles/scss/ -o src/styles/css/",
+    "watch-css": "npm run build-css && node-sass-chokidar src/styles/scss/ -o src/styles/css/ --watch --recursive",
+    "start-js": "node scripts/start.js",
+    "start": "npm-run-all -p watch-css start-js",
+    "build-js": "node scripts/build.js",
+    "build": "npm-run-all build-css build-js",
     "test": "node scripts/test.js --env=jsdom"
   },
   "devDependencies": {
     "less-watch-compiler": "^1.11.0",
-    "node-sass": "^4.7.2",
+    "node-sass-chokidar": "^1.2.2",
+    "npm-run-all": "^4.1.2",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.20.2"
   },

--- a/src/styles/scss/_Tree.scss
+++ b/src/styles/scss/_Tree.scss
@@ -8,9 +8,9 @@
     	padding: 0.5em 2em;
 	}
     .dir {
-    	background: url(/images/icons/folder.svg) left no-repeat;
+    	background: url(../../images/icons/folder.svg) left no-repeat;
     }
     .file {
-    	background: url(/images/icons/file-text.svg) left no-repeat;
+    	background: url(../../images/icons/file-text.svg) left no-repeat;
     }
 }


### PR DESCRIPTION
In order to get this to work I had to disable `url()` resolving by the webpack `css-loader`. None of the options seemed to address our particular use case: https://github.com/webpack-contrib/css-loader#url
Note that react's build will put anything in the `static` directory at the root of the output directory, while the css gets put at `static/css`, so the path to images needs to be prefixed with `../..`
It feels like I'm missing a better way to do this, but at least this should fix the immediate problem of missing images.

I also removed the sass module as it doesn't support the `--watch` parameter (that's from the ruby sass implementation) and replaced it with `node-sass-chokidar` as suggested in [create-react-app](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-a-css-preprocessor-sass-less-etc)