### PR TITLE
Cancel running fetch operations when url changes

### DIFF
--- a/src/components/Commit.js
+++ b/src/components/Commit.js
@@ -35,7 +35,7 @@ class Commits extends Component {
     const commit = await Git.fetch(cid)
     this.setState({ commit })
 
-    commit.fetchChanges(changes => this.setState(changes))
+    commit.fetchDiff(changes => this.setState(changes))
   }
 }
 

--- a/src/components/Commits.js
+++ b/src/components/Commits.js
@@ -44,11 +44,20 @@ class Commits extends Component {
   }
 
   triggerFetch(commitCid) {
-    if (this.fetchedCommit === commitCid) return
-    this.fetchedCommit = commitCid
+    // Check if we're already processing this commit
+    if ((this.currentCommit || {}).cid === commitCid) return
 
-    // fetch one extra row for pagination purposes
-    GitCommit.fetchCommitAndParents(commitCid, this.rowCount + 1, commits => {
+    // If we were fetching another commit, cancel it
+    if ((this.currentCommit || {}).fetch) {
+      this.currentCommit.fetch.cancel()
+    }
+    this.currentCommit = {
+      cid: commitCid
+    }
+
+    // Fetch one extra row for pagination purposes
+    const rowCount = this.rowCount + 1
+    this.currentCommit.fetch = GitCommit.fetchCommitAndParents(commitCid, rowCount, commits => {
       this.setState({ commits })
     })
   }

--- a/src/lib/git/GitCommit.js
+++ b/src/lib/git/GitCommit.js
@@ -2,6 +2,8 @@ import CID from 'cids'
 import moment from 'moment'
 import Git from './Git'
 
+const COMMIT_SUMMARY_LEN = 80
+
 class Fetcher {
   start() {
     this.running = true
@@ -12,7 +14,7 @@ class Fetcher {
   }
 }
 
-class CommitAndParentsFetcher extends Fetcher {
+class RecursiveCommitFetcher extends Fetcher {
   constructor(cid, countRequired, onUpdate) {
     super()
     this.cid = cid
@@ -59,7 +61,7 @@ class CommitAndParentsFetcher extends Fetcher {
   }
 }
 
-class ChangesFetcher extends Fetcher {
+class DiffFetcher extends Fetcher {
   constructor(cid, parents, onUpdate) {
     super()
     this.cid = cid
@@ -156,8 +158,8 @@ class GitCommit {
     this.committer.moment  = moment(this.author.date, 'X ZZ')
 
     this.summary = this.message
-    if (this.message.length > 80) {
-      this.summary = this.message.substring(0, 80) + '...'
+    if (this.message.length > COMMIT_SUMMARY_LEN) {
+      this.summary = this.message.substring(0, COMMIT_SUMMARY_LEN) + '...'
     }
 
     const parents = []
@@ -174,18 +176,17 @@ class GitCommit {
   }
 
   // Compare this commit's tree to its parent tree
-  fetchChanges(onUpdate) {
-    const fetcher = new ChangesFetcher(this.cid, this.parents, onUpdate)
+  fetchDiff(onUpdate) {
+    const fetcher = new DiffFetcher(this.cid, this.parents, onUpdate)
     fetcher.start()
     return fetcher
   }
 
   static fetchCommitAndParents(cid, countRequired, onUpdate) {
-    const fetcher = new CommitAndParentsFetcher(cid, countRequired, onUpdate)
+    const fetcher = new RecursiveCommitFetcher(cid, countRequired, onUpdate)
     fetcher.start()
     return fetcher
   }
 }
 
 export default GitCommit
-

--- a/src/lib/git/GitCommit.js
+++ b/src/lib/git/GitCommit.js
@@ -2,67 +2,117 @@ import CID from 'cids'
 import moment from 'moment'
 import Git from './Git'
 
-class GitCommit {
-  constructor(data, cid) {
-    Object.assign(this, data)
+class Fetcher {
+  start() {
+    this.running = true
+    return this.run().then(() => this.running = false)
+  }
+  cancel() {
+    this.running = false
+  }
+}
+
+class CommitAndParentsFetcher extends Fetcher {
+  constructor(cid, countRequired, onUpdate) {
+    super()
     this.cid = cid
-
-    this.author.moment = moment(this.author.date, 'X ZZ')
-    this.committer.moment  = moment(this.author.date, 'X ZZ')
-
-    this.summary = this.message
-    if (this.message.length > 80) {
-      this.summary = this.message.substring(0, 80) + '...'
-    }
-
-    const parents = []
-    const vp = this.parents || []
-    vp.forEach(p => {
-      if (!(p || {})['/']) return
-
-      try {
-        p.cid = new CID(p['/']).toBaseEncodedString()
-        parents.push(p)
-      } catch(e) {}
-    })
-    this.parents = parents
+    this.countRequired = countRequired
+    this.onUpdate = onUpdate
+    this.count = 0
+    this.fetched = {}
+    this.commits = []
   }
 
-  // Compare this commit's tree to its parent tree
-  fetchChanges(onUpdate) {
-    if (!this.parents.length) return
+  run() {
+    return this.fetch(this.cid)
+  }
 
-    let stateChanges = []
-    const fetchTrees = async (t1, t2) => {
-      const trees = await Promise.all([
-        Git.fetch(t1),
-        Git.fetch(t2)
-      ])
-      const changes = this.getChanges(...trees)
-      changes.forEach(async c => {
-        // If the change is a directory, recursively drill down into the directory
-        if (c.change[0].isDir() && c.change[1].isDir()) {
-          return fetchTrees(c.change[0].cid, c.change[1].cid)
-        }
+  fetch(cid) {
+    if (!this.running) return
 
-        // Get the contents of the files
-        const files = await Promise.all(c.change.map(f => f && f.fetchContents()))
-
-        // As we retrieve the contents for each change, update
-        // the state so the diff is rendered, making sure to keep
-        // files in lexicographical order
-        stateChanges = stateChanges.concat({
-          name: c.name,
-          change: files
-        }).sort((a, b) => {
-          if (a.name < b.name) return -1
-          if (a.name > b.name) return 1
-          return 0
-        })
-        onUpdate({ changes: stateChanges })
-      })
+    // If we've collected enough commits, we're done
+    if (this.count >= this.countRequired) {
+      return
     }
-    fetchTrees(`${this.cid}/tree`, `${this.cid}/parents/0/tree`)
+
+    // If we've already fetched this commit, skip it
+    if (this.fetched[cid]) {
+      return
+    }
+    this.fetched[cid] = true
+
+    // Fetch a commit
+    return Git.fetch(cid).then(async commit => {
+      if (!this.running) return
+
+      this.count++
+
+      // Update the list of commits
+      this.commits = this.commits.concat([commit])
+      this.onUpdate(this.commits.slice(0, this.countRequired))
+
+      // Fetch the parents of the commit in reverse order
+      for (let i = commit.parents.length - 1; i >= 0; i--) {
+        await this.fetch(commit.parents[i].cid)
+      }
+    })
+  }
+}
+
+class ChangesFetcher extends Fetcher {
+  constructor(cid, parents, onUpdate) {
+    super()
+    this.cid = cid
+    this.parents = parents
+    this.onUpdate = onUpdate
+    this.stateChanges = []
+  }
+
+  run() {
+    if (!this.parents.length) {
+      this.cancel()
+      return
+    }
+
+    return this.fetchTrees(`${this.cid}/tree`, `${this.cid}/parents/0/tree`)
+  }
+
+  async fetchTrees(t1, t2) {
+    if (!this.running) return
+
+    const trees = await Promise.all([
+      Git.fetch(t1),
+      Git.fetch(t2)
+    ])
+
+    const changes = this.getChanges(...trees)
+    await Promise.all(changes.map(async c => {
+      if (!this.running) return
+
+      // If the change is a directory, recursively drill down into the directory
+      if (c.change[0] && c.change[0].isDir() && c.change[1] && c.change[1].isDir()) {
+        return this.fetchTrees(c.change[0].cid, c.change[1].cid)
+      }
+
+      // Get the contents of the files
+      const files = await Promise.all(c.change.map(f => f && f.fetchContents()))
+
+      // As we retrieve the contents for each change, update
+      // the state so the diff is rendered, making sure to keep
+      // files in lexicographical order
+      this.stateChanges = this.stateChanges.concat({
+        name: c.name,
+        change: files
+      }).sort((a, b) => {
+        if (a.name < b.name) return -1
+        if (a.name > b.name) return 1
+        return 0
+      })
+
+      if (!this.running) return
+
+      this.onUpdate({ changes: this.stateChanges })
+    }))
   }
 
   getChanges(head, parent) {
@@ -95,38 +145,45 @@ class GitCommit {
       return !c.change[0] || !c.change[1] || c.change[0].cid !== c.change[1].cid
     })
   }
+}
 
-  static fetchCommitAndParents(cid, total, onUpdate) {
-    let count = 0
-    const fetched = {}
-    let commits = []
-    const fetch = (currCid) => {
-      // If we've collected enough commits, we're done
-      if (count >= total) {
-        return
-      }
+class GitCommit {
+  constructor(data, cid) {
+    Object.assign(this, data)
+    this.cid = cid
 
-      // If we've already fetched this commit, skip it
-      if (fetched[currCid]) {
-        return
-      }
-      fetched[currCid] = true
+    this.author.moment = moment(this.author.date, 'X ZZ')
+    this.committer.moment  = moment(this.author.date, 'X ZZ')
 
-      // Fetch a commit
-      return Git.fetch(currCid).then(async commit => {
-        count++
-
-        // Update the list of commits
-        commits = commits.concat([commit])
-        onUpdate(commits.slice(0, this.rowCount))
-
-        // Fetch the parents of the commit in reverse order
-        for (let i = commit.parents.length - 1; i >= 0; i--) {
-          await fetch(commit.parents[i].cid)
-        }
-      })
+    this.summary = this.message
+    if (this.message.length > 80) {
+      this.summary = this.message.substring(0, 80) + '...'
     }
-    fetch(cid)
+
+    const parents = []
+    const vp = this.parents || []
+    vp.forEach(p => {
+      if (!(p || {})['/']) return
+
+      try {
+        p.cid = new CID(p['/']).toBaseEncodedString()
+        parents.push(p)
+      } catch(e) {}
+    })
+    this.parents = parents
+  }
+
+  // Compare this commit's tree to its parent tree
+  fetchChanges(onUpdate) {
+    const fetcher = new ChangesFetcher(this.cid, this.parents, onUpdate)
+    fetcher.start()
+    return fetcher
+  }
+
+  static fetchCommitAndParents(cid, countRequired, onUpdate) {
+    const fetcher = new CommitAndParentsFetcher(cid, countRequired, onUpdate)
+    fetcher.start()
+    return fetcher
   }
 }
 


### PR DESCRIPTION
So that when the user clicks through to a link before the fetch for the current page completes, the completed fetch doesn't re-render the (previous) page