### PR TITLE
Use repo cid as root (instead of commit cid)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -25,9 +25,9 @@ class App extends Component {
           <Switch>
             <Route exact path="/" component={Home}/>
             <Route exact path="/new/repo" component={NewRepo}/>
-            <Route path="/repo/:repoCid/commits" component={Commits}/>
+            <Route path="/repo/:repoCid/commit/:commitCid" component={Commit}/>
+            <Route path="/repo/:repoCid/commits/:branch" component={Commits}/>
             <Route path="/repo/:repoCid" component={Repo}/>
-            <Route path="/commit/:commitCid" component={Commit}/>
           </Switch>
         </main>
       </div>

--- a/src/components/BranchSelector.js
+++ b/src/components/BranchSelector.js
@@ -1,0 +1,44 @@
+import React, { Component } from 'react'
+import Url from '../lib/Url'
+
+class BranchSelector extends Component {
+  render() {
+    if (!this.props.repo) return null
+
+    return (
+      <div className="BranchSelector">
+        <div className="title">Branch:</div>
+      	<select onChange={e => this.handleChange(e)} value={this.props.branch}>
+          {this.renderOptions(this.props.repo.branches)}
+        </select>
+      </div>
+    )
+  }
+
+  renderOptions(branches) {
+    return Object.keys(branches).sort((a, b) => this.compareBranches(a, b)).map(this.branchNick).map(b =>
+      <option key={b} value={b}>{b}</option>
+    )
+  }
+
+  handleChange(event) {
+    window.location.href = '#' + Url.toBranch(this.props.repo, event.target.value)
+  }
+
+  branchNick(branch) {
+    return branch.replace('refs/heads/', '')
+  }
+
+  compareBranches(a, b) {
+    // Make sure default branch is at the top (eg master)
+    if (a === this.props.repo.defaultBranch) return -1
+    if (b === this.props.repo.defaultBranch) return 1
+
+    if (a < b) return -1
+    if (a > b) return 1
+
+    return 0
+  }
+}
+
+export default BranchSelector

--- a/src/components/BreadCrumb.js
+++ b/src/components/BreadCrumb.js
@@ -1,11 +1,12 @@
 import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
+import Url from '../lib/Url'
 
 class BreadCrumb extends Component {
   render() {
-    // Don't show breadcrumbs if it's just /repo/<cid>
+    // Don't show breadcrumbs if there's no file path
     const crumbs = this.props.crumbs
-    if ((crumbs || []).length < 2) {
+    if ((crumbs || []).length <= 1) {
       return null
     }
 
@@ -16,13 +17,14 @@ class BreadCrumb extends Component {
 
   renderCrumbs(crumbs) {
     return crumbs.map((c, i) => {
-      const linkPath = this.props.path + '/' + crumbs.slice(0, i + 1).join('/')
+      const filePath = [''].concat(crumbs.slice(1, i + 1)).join('/')
+      const linkPath = Url.toBranch(this.props.repo, this.props.branch) + filePath
       // Shorten cid
       const name = i === 0 ? c.substring(0, 8) : c
       return (
         <div key={i}>
           {i > 0 && <div className="separator">/</div>}
-          {i < crumbs.length -1 ? (
+          {i < crumbs.length - 1 ? (
             <Link to={linkPath} className="crumb">{name}</Link>
           ) : (
             <div className="crumb">{name}</div>

--- a/src/components/Commit.js
+++ b/src/components/Commit.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import CommitDiffList from "./CommitDiffList"
 import CommitTitle from "./CommitTitle"
 import Git from "../lib/git/Git"
+import Url from '../lib/Url'
 
 class Commits extends Component {
   constructor(props) {
@@ -29,10 +30,8 @@ class Commits extends Component {
     if (this.initialized) return
     this.initialized = true
 
-    // /commit/<cid>
-    const parts = pathname.split('/')
-    let cid = parts[2]
-    const commit = await Git.fetch(cid)
+    const url = Url.parseCommitPath(pathname)
+    const commit = await Git.fetch(url.commitCid)
     this.setState({ commit })
 
     commit.fetchDiff(changes => this.setState(changes))

--- a/src/components/CommitList.js
+++ b/src/components/CommitList.js
@@ -3,9 +3,7 @@ import CommitListItem from './CommitListItem'
 
 class CommitList extends Component {
   render() {
-    if (!(this.props.commits || []).length) {
-      return <div>Loading</div>
-    }
+    if (!(this.props.commits || []).length) return null
 
     return (
       <div className="CommitList">
@@ -16,7 +14,7 @@ class CommitList extends Component {
 
   renderCommits(commits) {
     return commits.map(c =>
-      <CommitListItem key={c.cid} commit={c} />
+      <CommitListItem key={c.cid} repoCid={this.props.repoCid} commit={c} />
     )
   }
 }

--- a/src/components/CommitListItem.js
+++ b/src/components/CommitListItem.js
@@ -11,7 +11,7 @@ class CommitListItem extends Component {
           {commit.author.name}
         </div>
         <div className="description">
-          <Link to={`/commit/${commit.cid}`}>{commit.summary}</Link>
+          <Link to={`/repo/${this.props.repoCid}/commit/${commit.cid}`}>{commit.summary}</Link>
         </div>
         <div className="at">
           {commit.author.moment.fromNow()}

--- a/src/components/CommitTitle.js
+++ b/src/components/CommitTitle.js
@@ -3,9 +3,7 @@ import React, { Component } from 'react'
 class CommitTitle extends Component {
   render() {
     const commit = this.props.commit
-    if (!commit) {
-      return <div>Loading</div>
-    }
+    if (!commit) return null
 
     return (
       <div className="CommitTitle">

--- a/src/components/Commits.js
+++ b/src/components/Commits.js
@@ -1,7 +1,9 @@
 import React, { Component } from 'react'
 import CommitList from "./CommitList"
 import GitCommit from '../lib/git/GitCommit'
+import GitRepo from '../lib/git/GitRepo'
 import { Link } from 'react-router-dom'
+import Url from '../lib/Url'
 
 class Commits extends Component {
   constructor(props) {
@@ -12,30 +14,23 @@ class Commits extends Component {
 
   render() {
     const pathname = this.props.location.pathname
-
-    // /repo/<cid>/commits
-    // or
-    // /repo/<cid>/commits/<commit cid>
-    const parts = pathname.split('/')
-    const basePath = parts.slice(0, 2).join('/')
-    const repoCid = parts[2]
-    const commitCid = parts[4]
+    const url = Url.parseCommitsPath(pathname)
 
     // If we have not yet fetched the data for the commit list, continue with
     // rendering but trigger a fetch in the background (which will
     // call render again on completion)
-    this.triggerFetch(commitCid || repoCid)
+    this.triggerFetch(url.repoCid, url.branch, url.commitCid)
 
     // If there is another commit in the list, show the more link
     let more = null
     if (this.state.commits.length > this.rowCount) {
       const nextCommit = this.state.commits[this.rowCount]
-      more = <Link to={`${basePath}/${repoCid}/commits/${nextCommit.cid}`}>More ▾</Link>
+      more = <Link to={`${url.basePath}/${nextCommit.cid}`}>More ▾</Link>
     }
 
     return (
       <div className="Commits">
-        <CommitList path={basePath} commits={this.state.commits.slice(0, this.rowCount)} />
+        <CommitList repoCid={url.repoCid} commits={this.state.commits.slice(0, this.rowCount)} />
         <div className="more-link">
           {more}
         </div>
@@ -43,7 +38,27 @@ class Commits extends Component {
     )
   }
 
-  triggerFetch(commitCid) {
+  async triggerFetch(repoCid, branch, commitCid) {
+    if (this.repoFetched) {
+      this.triggerCommitsFetch(branch, commitCid)
+      return
+    }
+    this.repoFetched = true
+
+    // Get the repo
+    return GitRepo.fetch(repoCid, repo => {
+      this.setState({ repo })
+      this.triggerCommitsFetch(branch, commitCid)
+    })
+  }
+
+  triggerCommitsFetch(branch, commitCid) {
+    const repo = this.state.repo
+    if (!repo) return
+
+    commitCid = commitCid || (repo.headCommit(branch) || {}).cid
+    if (!commitCid) return
+
     // Check if we're already processing this commit
     if ((this.currentCommit || {}).cid === commitCid) return
 

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -6,7 +6,7 @@ class Home extends Component {
     return (
       <span className="Home">
         <p>Welcome to IGiS</p>
-        <p>Take a look at the <Link to="/repo/z8mWaFhNutrvGaKNcybtLjgLMEC3n5tC5">Demo Tree</Link></p>
+        <p>Take a look at the <Link to="/repo/QmViWi5az9iiPzESM6ruHf84TcmHSAVQ2KQdNveoDH7eaY">Demo Tree</Link></p>
         <p>Check out the source code at <a href="https://github.com/ipfs-shipyard/IGiS">https://github.com/ipfs-shipyard/IGiS</a></p>
       </span>
     );

--- a/src/components/RepoLinks.js
+++ b/src/components/RepoLinks.js
@@ -1,14 +1,21 @@
+import BranchSelector from "./BranchSelector"
+import BreadCrumb from "./BreadCrumb"
 import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
 import ZipButton from './ZipButton'
 
 class RepoLinks extends Component {
   render() {
+  	if (!this.props.repo) return null
+
+    const crumbs = [this.props.repo.cid].concat(this.props.url.filePathParts)
     return (
       <div className="RepoLinks">
+      	<BranchSelector repo={this.props.repo} branch={this.props.branch} />
+        <BreadCrumb repo={this.props.repo} branch={this.props.branch} crumbs={crumbs} />
         <div className="commits">
-          <Link to={`/repo/${this.props.cid}/commits`}>Commits</Link>
-          <ZipButton cid={this.props.cid} />
+          <ZipButton cid={(this.props.repo.headCommit(this.props.branch) || {}).cid} />
+          <Link to={`/repo/${this.props.repo.cid}/commits/${encodeURIComponent(this.props.branch)}`}>Commits</Link>
         </div>
       </div>
     );

--- a/src/components/StatusBar.js
+++ b/src/components/StatusBar.js
@@ -9,7 +9,7 @@ class StatusBar extends Component {
           IGiS
         </div>
         <div className="menu">
-          <Link to="/repo/z8mWaFhNutrvGaKNcybtLjgLMEC3n5tC5">Demo Tree</Link>
+          <Link to="/repo/QmViWi5az9iiPzESM6ruHf84TcmHSAVQ2KQdNveoDH7eaY">Demo Tree</Link>
           <Link to="/new/repo">New Repository</Link>
         </div>
       </div>

--- a/src/components/Tree.js
+++ b/src/components/Tree.js
@@ -16,7 +16,7 @@ class Tree extends Component {
 
   renderFiles(files) {
     return files.sort(Tree.compareFiles).map(file =>
-      <TreeItem key={file.name} basePath={this.props.path} file={file} />
+      <TreeItem key={file.name} repo={this.props.repo} tree={this.props.tree} file={file} />
     )
   }
 

--- a/src/components/TreeItem.js
+++ b/src/components/TreeItem.js
@@ -1,14 +1,15 @@
 import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
+import Url from '../lib/Url'
 
 class TreeItem extends Component {
   render() {
-    const { file, basePath } = this.props
+    const { repo, tree, file } = this.props
     let c = 'item '
     c += file.isDir() ? 'dir' : 'file'
 
     return (
-      <Link to={basePath + '/' + file.name} className={c}>
+      <Link to={Url.toFile(repo, tree, file)} className={c}>
         {file.name}
       </Link>
     )

--- a/src/components/ZipButton.js
+++ b/src/components/ZipButton.js
@@ -48,19 +48,17 @@ class ZipButton extends Component {
   }
 
   render() {
-    if(this.state.processing) {
-      return (
-        <span>
-          Zip: processing {this.state.current}
-        </span>
-      );
-    }
-
+    if (!this.props.cid) return null
+    
     return (
-      <span>
-        <a href='#' onClick={this.handleClick}>Download Zip</a>
+      <span className="ZipButton">
+        { this.state.processing ? (
+          <span>Zip: processing {this.state.current}</span>
+        ) : (
+          <a href='#' onClick={this.handleClick}>Download Zip</a>
+        )}
       </span>
-    );
+    )
   }
 }
 

--- a/src/lib/Url.js
+++ b/src/lib/Url.js
@@ -1,0 +1,62 @@
+import GitRepo from './git/GitRepo'
+
+class Url {
+  static toFile(repo, tree, file) {
+    // <cid>/tree/some/hash/path/hash/to/hash/file.go
+    const treePathParts = tree.path.split('/')
+    const treeCid = treePathParts[0]
+    const path = treePathParts.slice(1).filter((p, i) => i % 2 === 1).concat([file.name]).join('/')
+    const branchPath = (Object.entries(repo.branches).find(([b, o]) => o.cid === treeCid) || [])[0]
+    const branch = GitRepo.branchNick(branchPath)
+    const type = file.isDir() ? 'tree' : 'blob'
+    return `/repo/${repo.cid}/${type}/${encodeURIComponent(branch)}/${path}`
+  }
+
+  static toBranch(repo, branch) {
+    return `/repo/${repo.cid}/tree/${encodeURIComponent(branch)}`
+  }
+
+  static parseRepoPath(url) {
+    // /repo/<cid>/blob/<branch>/some/path.ext
+    const parts = url.split('/')
+    if (parts[1] !== 'repo') return {}
+
+    return {
+      parts: parts,
+      repoCid: parts[2],
+      gitType: parts[3],
+      branch: parts[4] && decodeURIComponent(parts[4]),
+      basePath: parts.slice(0, 5).join('/'),
+      filePath: parts.slice(5).join('/') || undefined,
+      filePathParts: parts.slice(5)
+    }
+  }
+
+  static parseCommitsPath(url) {
+    // /repo/<cid>/commits/<branch>/<commit cid>
+    const parts = url.split('/')
+    if (parts[1] !== 'repo') return {}
+
+    return {
+      parts: parts,
+      repoCid: parts[2],
+      branch: parts[4] && decodeURIComponent(parts[4]),
+      commitCid: parts[5],
+      basePath: parts.slice(0, 5).join('/')
+    }
+  }
+
+  static parseCommitPath(url) {
+    // /repo/<cid>/commit/<commit cid>
+    const parts = url.split('/')
+    if (parts[1] !== 'repo') return {}
+
+    return {
+      parts: parts,
+      repoCid: parts[2],
+      commitCid: parts[4]
+    }
+  }
+}
+
+export default Url

--- a/src/lib/git/GitRepo.js
+++ b/src/lib/git/GitRepo.js
@@ -1,0 +1,65 @@
+import CID from 'cids'
+import { DAGNode } from 'ipld-dag-pb'
+import GitCommit from './GitCommit'
+
+const DEFAULT_HEAD_REF = 'refs/heads/master'
+const MAX_REFS_DEPTH = 10
+
+class GitRepo {
+  constructor(cid, defaultBranch, branches) {
+    this.cid = cid
+    this.defaultBranch = defaultBranch
+    this.branches = branches
+  }
+
+  headCommit(branch) {
+    const branchPath = branch ? 'refs/heads/' + branch : this.defaultBranch
+    return (this.branches || {})[branchPath]
+  }
+
+  static branchNick(branchPath) {
+    return (branchPath || '').replace('refs/heads/', '')
+  }
+
+  static async fetch(cid, onUpdate) {
+    const repo = await window.ipfs.dag.get(cid).then(r => r.value)
+
+    const [defaultBranch, branches] = await Promise.all([
+      this.getDefaultBranch(repo),
+      this.getBranchHeads(repo)
+    ])
+
+    onUpdate(new GitRepo(cid, defaultBranch, branches))
+  }
+
+  static async getDefaultBranch(repo) {
+    const head = repo.links.find(l => l.name === 'HEAD')
+    if (!head) return DEFAULT_HEAD_REF
+
+    const headHash = new CID(head.multihash).toBaseEncodedString()
+    return window.ipfs.files.cat(headHash).then(h => h.toString())
+  }
+
+  static async getBranchHeads(node) {
+    const branches = {}
+    await this.walkBranchDir(branches, '', node, 1)
+    return branches
+  }
+
+  static walkBranchDir(branches, path, node, depth) {
+    if (depth > MAX_REFS_DEPTH) return
+
+    return Promise.all(node.links.map(async l => {
+      const cid = new CID(l.multihash).toBaseEncodedString()
+      const obj = await window.ipfs.dag.get(cid).then(r => r.value)
+      if (obj instanceof DAGNode) {
+        return this.walkBranchDir(branches, path + l.name + '/', obj, depth + 1)
+      }
+      if(obj.gitType === 'commit') {
+        branches[path + l.name] = new GitCommit(obj, cid)
+      }
+    }))
+  }
+}
+
+export default GitRepo

--- a/src/styles/scss/_BranchSelector.scss
+++ b/src/styles/scss/_BranchSelector.scss
@@ -1,0 +1,18 @@
+.BranchSelector {
+	display: inline-block;
+
+    .title {
+        display: inline-block;
+        margin: 0 0.5em 0 0;
+    }
+    select {
+        background: transparent;
+	    border: none;
+	    font-size: inherit;
+	    font-weight: inherit;
+	    font-family: inherit;
+	    color: #9b4dca;
+	    cursor: pointer;
+	    outline: none;
+    }
+}

--- a/src/styles/scss/_BreadCrumb.scss
+++ b/src/styles/scss/_BreadCrumb.scss
@@ -1,5 +1,6 @@
 .BreadCrumb {
-    padding: 0.5em 0.5em 0 0.5em;
+    display: inline-block;
+    padding: 0.5em 0.5em 0 1em;
     
     div {
         display: inline-block;

--- a/src/styles/scss/_RepoLinks.scss
+++ b/src/styles/scss/_RepoLinks.scss
@@ -1,11 +1,11 @@
 .RepoLinks {
     padding: 0.5em;
 
-    > .commits {
-        display: flex;
-
-        > * {
-            padding: 5px;
-        }
+    .commits {
+    	display: inline-block;
+    	float: right;
+    }
+    .ZipButton {
+        margin: 0 0.5em 0 0;
     }
 }

--- a/src/styles/scss/main.scss
+++ b/src/styles/scss/main.scss
@@ -3,6 +3,7 @@
 @import "../../../node_modules/highlight.js/styles/default.css";
 
 @import "App";
+@import "BranchSelector";
 @import "BreadCrumb";
 @import "Commits";
 @import "CommitDiffFile";


### PR DESCRIPTION
The url now takes a repo cid instead of a commit cid as the root, where the repo is an IPFS object with the structure:
```
{
  "HEAD": "refs/heads/master",
  "refs": {
    "heads": {
      "master": <z8mWaFytVvoQSUxEjaVqC3MrFMH9ZT435>,
      "archive": {
        "scala": <z8mWaGm8DnUkeudLyvNqAHJsdRpYoxGuB>
      },
      ...
    }
  }
}
```

Default branch:
<img width="1186" alt="screen shot 2018-04-26 at 2 47 17 pm" src="https://user-images.githubusercontent.com/169124/39290299-b86acf64-4961-11e8-80c2-cea1d7efc536.png">

Different branch:
<img width="1203" alt="screen shot 2018-04-26 at 2 47 36 pm" src="https://user-images.githubusercontent.com/169124/39290307-bf30da0a-4961-11e8-8965-8db9ee112e90.png">

Commits page:
<img width="1193" alt="screen shot 2018-04-26 at 2 47 53 pm" src="https://user-images.githubusercontent.com/169124/39290316-c26145e8-4961-11e8-8494-7116c432b744.png">
